### PR TITLE
chore: add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,43 @@
+name: Release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: https://registry.npmjs.org
+
+      - name: Install pnpm
+        run: npm install -g pnpm
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Run tests
+        run: pnpm test
+
+      - name: Build
+        run: pnpm build
+
+      - name: Publish to npm
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Publish to GitHub Packages
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          ORIGINAL_NAME=$(node -p "require('./package.json').name")
+          npm pkg set name="@${{ github.repository_owner }}/gmol"
+          npm publish --registry=https://npm.pkg.github.com
+          npm pkg set name="$ORIGINAL_NAME"


### PR DESCRIPTION
## Summary
- add release workflow that publishes to npm and GitHub Packages on release

## Testing
- `pnpm test` *(fails: expected { Cu: 1, S: 1, O: 5, H: 10 } to deeply equal { Cu: 1, S: 1, O: 9, H: 10 })*


------
https://chatgpt.com/codex/tasks/task_e_68bdac874b488324af28527f1b2eec60