### PR TITLE
Add .npmrc for GitHub Packages registry

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+@OWNER:registry=https://npm.pkg.github.com
+//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}


### PR DESCRIPTION
## Summary
- add .npmrc to configure GitHub Packages registry and auth token

## Testing
- `pnpm test` *(fails: parseFormula > parses hydrate dot)*

------
https://chatgpt.com/codex/tasks/task_e_68bdb0e16a70832484707f1b4b4e5d6c