### PR TITLE
Fix hydrate coefficient handling for hydrate formulas

### DIFF
--- a/src/core/parser.ts
+++ b/src/core/parser.ts
@@ -69,14 +69,13 @@ function parseSequence(
         );
       }
       if (next.t === "ELEMENT") {
-        idx.i++;
-        const el = next.v;
-        let mult = 1;
-        if (tokens[idx.i]?.t === "NUMBER") {
-          mult = (tokens[idx.i] as any).v;
-          idx.i++;
+        const inner = parseSequence(tokens, idx, stopOn);
+        if (!Object.keys(inner).length) {
+          throw new Error(
+            `Coefficient ${coeff} must precede an element or group`
+          );
         }
-        out[el] = (out[el] ?? 0) + coeff * mult;
+        mergeCounts(out, inner, coeff);
         continue;
       }
       if (next.t === "LP") {


### PR DESCRIPTION
## Summary
- update the parser to apply leading coefficients to the subsequent molecular sequence, allowing hydrate notation like 5H₂O to be parsed correctly

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68f375a4497c8324a9e1048d5ae63a23