### PR TITLE
Fix GitHub Packages publish auth

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Publish to GitHub Packages
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.GH_PKG_TOKEN }}
         run: |
           ORIGINAL_NAME=$(node -p "require('./package.json').name")
           npm pkg set name="@${{ github.repository_owner }}/gmol"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,9 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
 
     steps:
       - uses: actions/checkout@v4
@@ -35,9 +38,10 @@ jobs:
 
       - name: Publish to GitHub Packages
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.PUBLISH_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           ORIGINAL_NAME=$(node -p "require('./package.json').name")
           npm pkg set name="@${{ github.repository_owner }}/gmol"
-          npm publish --registry=https://npm.pkg.github.com
+          npm config set @${{ github.repository_owner }}:registry https://npm.pkg.github.com
+          npm publish --registry=https://npm.pkg.github.com --//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}
           npm pkg set name="$ORIGINAL_NAME"


### PR DESCRIPTION
## Summary
- grant the workflow packages:write permission and publish using the automatically provided GITHUB_TOKEN
- configure the GitHub Packages scope before publishing while keeping .npmrc templated with @OWNER

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68f38022d58c8324972a6cce0b7cbbb4